### PR TITLE
Add git safe directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -P / https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-b
 RUN chmod a+x /*.sh
 
 # Install phpstan globally
-RUN composer global require phpstan/phpstan:1.2.0 --prefer-dist \
+RUN composer global require phpstan/phpstan:1.6 --prefer-dist \
 	&& composer clear-cache
 
 VOLUME ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -P / https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-b
 RUN chmod a+x /*.sh
 
 # Install phpstan globally
-RUN composer global require phpstan/phpstan:1.6 --prefer-dist \
+RUN composer global require phpstan/phpstan:1.7 --prefer-dist \
 	&& composer clear-cache
 
 VOLUME ["/app"]

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -101,6 +101,12 @@ run_phpstan() {
      fi
 }
 
+git_allow_access() {
+     debug "Granting git safe access to bitbucket build directory..."
+     git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
+}
+
+git_allow_access
 validate
 if [ $SKIP_DEPENDENCIES = false ]; then
      setup_ssh_creds


### PR DESCRIPTION
Set the bitbucket volume directory as a safe directory for git to access as pipelines are currently failing due to the below error message.

```
fatal: unsafe repository ('/opt/atlassian/pipelines/agent/build' is owned by someone else)
To add an exception for this directory, call:
	git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
```