### PR TITLE
Add /app to the safe directory list to allow local run

### DIFF
--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -102,8 +102,9 @@ run_phpstan() {
 }
 
 git_allow_access() {
-     debug "Granting git safe access to bitbucket build directory..."
+     debug "Granting git safe access to the directories owned by someone else ..."
      git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
+     git config --global --add safe.directory /app
 }
 
 git_allow_access


### PR DESCRIPTION
This is to fix the error happening when run locally:
```
$ docker run -e SKIP_DEPENDENCIES=true -v $PWD:/app aligent/phpstan-pipe:8.1
Comparing HEAD against branch origin/master
fatal: unsafe repository ('/app' is owned by someone else)
To add an exception for this directory, call:
                                               
        git config --global --add safe.directory /app
```


Hmm, that said, `Comparing HEAD against branch origin/master` needs to be addressed, too, when it's not within the context of PR. 