### PR TITLE
Python migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*@adamjhall @aligent/dev-ops
+*@adamjhall @aligent/aligent-devops

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -P / https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-b
 RUN chmod a+x /*.sh
 
 # Install phpstan globally
-RUN composer global require phpstan/phpstan:1.2.0 --prefer-dist \
+RUN composer global require phpstan/phpstan:1.6 --prefer-dist \
 	&& composer clear-cache
 
 VOLUME ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget -P / https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-b
 RUN chmod a+x /*.sh
 
 # Install phpstan globally
-RUN composer global require phpstan/phpstan:1.6 --prefer-dist \
+RUN composer global require phpstan/phpstan:1.7 --prefer-dist \
 	&& composer clear-cache
 
 VOLUME ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,15 @@ RUN pip3 install --no-cache --upgrade pip setuptools
 RUN composer global require phpstan/phpstan:1.7 --prefer-dist \
 	&& composer clear-cache
 
+# Allow git access to
+RUN git config --global --add safe.directory /build
+RUN git config --global --add safe.directory /opt/atlassian/pipelines/agent/build/
+
 ENV PYTHONUNBUFFERED=1
 
+COPY pipe pipe.yml /
+RUN chmod a+x /pipe.py
 COPY requirements.txt /
 RUN python3 -m pip install --no-cache-dir -r /requirements.txt
-COPY pipe /
-RUN chmod a+x /pipe.py
 
 ENTRYPOINT ["/pipe.py"]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Add the following your `bitbucket-pipelines.yml` file:
             - pipe: docker://aligent/phpstan-pipe:latest
               variables:
                 SKIP_DEPENDENCIES: "false"
-                MAGENTO_USER: "${MAGENTO_USER}"
-                MAGENTO_PASS: "${MAGENTO_PASS}"
                 LEVEL: "0"
                 AUTOLOADER: "vendor/autoload.php"
                 IGNORE_PLATFORM_DEPENDENCIES: "false"
@@ -27,8 +25,6 @@ We have docker images built for the following PHP Versions: 7.3, 7.4, 8.0, 8.1
 | -----------------------------| ----------------------------------------------------------- |
 | DEBUG                        | (Optional) Turn on extra debug information. Default: `false`. |
 | SKIP_DEPENDENCIES            | (Optional) Skip installing project composer dependencies. Default: `false`. |
-| MAGENTO_USER                 | (Optional) Injects repo.magento.com user into auth.json |
-| MAGENTO_PASS                 | (Optional) Injects repo.magento.com password into auth.json|
 | LEVEL                        | (Optional) Which level to execute phpstan at. Default: `0`|
 | AUTOLOADER                   | (Optional) Which PHP Autoloader to use. Default: `vendor/autoload.php`|
 | IGNORE_PLATFORM_DEPENDENCIES | (Optional) Whether to install platform dependencies or not. Default: `false`|
@@ -42,5 +38,5 @@ The following command can be used to invoke the pipe locally:
 docker run -v $PWD:/app aligent/phpstan-pipe:<PHP-Version>
 ```
 
-Commits published to the `main` branch  will trigger an automated build for the each of the configured PHP version.
+Commits published to the `main` branch  will trigger an automated build for each of the configured PHP version.
 Commits to `staging` will do the same but image tags will be suffixed with `-experimiental`.

--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@ Add the following your `bitbucket-pipelines.yml` file:
 We have docker images built for the following PHP Versions: 7.3, 7.4, 8.0, 8.1
 ## Variables
 
-| Variable              | Usage                                                       |
-| -----------------------------| ----------------------------------------------------------- |
-| DEBUG                        | (Optional) Turn on extra debug information. Default: `false`. |
-| SKIP_DEPENDENCIES            | (Optional) Skip installing project composer dependencies. Default: `false`. |
-| LEVEL                        | (Optional) Which level to execute phpstan at. Default: `0`|
-| AUTOLOADER                   | (Optional) Which PHP Autoloader to use. Default: `vendor/autoload.php`|
-| IGNORE_PLATFORM_DEPENDENCIES | (Optional) Whether to install platform dependencies or not. Default: `false`|
+| Variable                     | Usage                                                                                                                                                       |
+|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SKIP_DEPENDENCIES            | (Optional) Skip installing project composer dependencies. Default: `false`.                                                                                 |
+| LEVEL                        | (Optional) Which level to execute phpstan at. Default: `0`                                                                                                  |
+| AUTOLOADER                   | (Optional) Which PHP Autoloader to use. Default: `vendor/autoload.php`                                                                                      |
+| IGNORE_PLATFORM_DEPENDENCIES | (Optional) Whether to install platform dependencies or not. Default: `false`                                                                                |
+| CONFIG_FILE                  | (Optional) Config file to use.                                                                                                                |
 | SCAN_DIRECTORY               | (Optional) Which directory to scan. This will override the default behavior of comparing only the changed files, and will instead scan this entire directory. |
-| EXCLUDE_EXPRESSION           | (Optional) A grep [regular expression](https://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html) to exclude files from standards testing|
+| EXCLUDE_EXPRESSION           | (Optional) A grep [regular expression](https://www.gnu.org/software/grep/manual/html_node/Basic-vs-Extended.html) to exclude files from standards testing   |
 
 ## Development
 
 The following command can be used to invoke the pipe locally:
 ```
-docker run -v $PWD:/app aligent/phpstan-pipe:<PHP-Version>
+docker run -it --env="SKIP_DEPENDENCIES=true" --env="AUTOLOADER=vendor/autoload.php" --env="LEVEL=9" --env="BITBUCKET_PR_DESTINATION_BRANCH=<DESTINATION_BRANCH" --env="DISABLE_REPORT=true" -v $PWD:/build --workdir=/build aligent/phpstan:<PHP-Version>
 ```
 
 Commits published to the `main` branch  will trigger an automated build for each of the configured PHP version.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following your `bitbucket-pipelines.yml` file:
                 IGNORE_PLATFORM_DEPENDENCIES: "false"
 ```
 
-We have docker images built for the following PHP Versions: 7.3, 7.4, 8.0
+We have docker images built for the following PHP Versions: 7.3, 7.4, 8.0, 8.1
 ## Variables
 
 | Variable              | Usage                                                       |
@@ -39,7 +39,7 @@ We have docker images built for the following PHP Versions: 7.3, 7.4, 8.0
 
 The following command can be used to invoke the pipe locally:
 ```
-docker run -v $PWD:/app aligent/phpstan-pipe:latest
+docker run -v $PWD:/app aligent/phpstan-pipe:<PHP-Version>
 ```
 
 Commits published to the `main` branch  will trigger an automated build for the each of the configured PHP version.

--- a/pipe.yml
+++ b/pipe.yml
@@ -1,5 +1,5 @@
 name: Aligent PHPStan Pipe
-image: aligent/phpstan-pipe:latest
+image: aligent/phpstan-pipe:8.0
 description: This pipe is used to run phpstan checks
 repository: git@bitbucket.org:aligent/aligent-phpstan-pipe.git 
 maintainer: adam.hall@aligent.com.au

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -150,7 +150,7 @@ class PHPStan(Pipe):
           capture_output=True,
           universal_newlines=True)
 
-        self.failure = False if phpstan.returncode == 0 else True
+        self.failure = phpstan.returncode != 0
 
         phpstan_output = phpstan.stdout
 

--- a/pipe/pipe.py
+++ b/pipe/pipe.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+from operator import sub
+import os
+import shutil
+from sre_constants import SUCCESS
+import subprocess
+from sys import stdout
+import sys
+import uuid
+import re
+from bitbucket import Bitbucket
+from bitbucket_pipes_toolkit import Pipe, get_logger
+
+
+logger = get_logger()
+schema = {
+    'SKIP_DEPENDENCIES': {'type': 'string', 'required': False},
+    'AUTOLOADER': {'type': 'string', 'required': False},
+    'IGNORE_PLATFORM_DEPENDENCIES': {'type': 'boolean', 'required': False},
+    'LEVEL': {'type': 'integer', 'required': False, 'min': 1, 'max': 9},
+    'EXCLUDE_EXPRESSION': {'type': 'string', 'required': False},
+    'CONFIG_FILE': {'type': 'string', 'required': False},
+}
+
+class PHPStan(Pipe):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Composer Configuration
+        self.skip_dependencies = True if self.get_variable(
+            'SKIP_DEPENDENCIES') else False
+        self.ignore_platform_dependencies = True if self.get_variable(
+            'IGNORE_PLATFORM_DEPENDENCIES') else False
+
+        # PHPStan Configuration
+        self.config_file = self.get_variable('CONFIG_FILE')
+        self.autoloader = self.get_variable('AUTOLOADER')
+        self.level = self.get_variable('LEVEL')
+        self.exclude_expression = self.get_variable('EXCLUDE_EXPRESSION')
+
+        # Bitbucket Configuration
+        self.bitbucket_workspace = os.getenv('BITBUCKET_WORKSPACE')
+        self.bitbucket_repo_slug = os.getenv('BITBUCKET_REPO_SLUG')
+        self.bitbucket_pipeline_uuid = os.getenv('BITBUCKET_PIPELINE_UUID')
+        self.bitbucket_step_uuid = os.getenv('BITBUCKET_STEP_UUID')
+        self.bitbucket_commit = os.getenv('BITBUCKET_COMMIT')
+
+    def setup_ssh_credentials(self):
+        ssh_dir = os.path.expanduser("~/.ssh/")
+        injected_ssh_config_dir = "/opt/atlassian/pipelines/agent/ssh"
+        identity_file = f"{injected_ssh_config_dir}/id_rsa_tmp"
+        known_servers_file = f"{injected_ssh_config_dir}/known_hosts"
+
+        if not os.path.exists(identity_file):
+            self.fail(message="No default SSH key configured in Pipelines.\n These are required to install internal composer packages. \n These should be generated in bitbucket settings at Pipelines > SSH Keys.")
+
+        if not os.path.exists(known_servers_file):
+            self.fail(message="No SSH known_hosts configured in Pipelines.")
+
+        os.mkdir(ssh_dir)
+        shutil.copy(identity_file, f"{ssh_dir}pipelines_id")
+
+        # Read contents of pipe-injected known hosts and pipe into
+        # runtime ssh config
+        with open(known_servers_file) as pipe_known_host_file:
+            with open(f"{ssh_dir}known_hosts", 'a') as known_host_file:
+                for line in pipe_known_host_file:
+                    known_host_file.write(line)
+
+        with open(f"{ssh_dir}config", 'a') as config_file:
+            config_file.write("IdentityFile ~/.ssh/pipelines_id")
+
+        subprocess.run(["chmod", "-R", "go-rwx", ssh_dir], check=True)
+
+    def run_phpstan(self):
+        target_branch = "origin/main"
+        if os.getenv("BITBUCKET_PR_DESTINATION_BRANCH"):
+            target_branch = f"origin/{os.getenv('BITBUCKET_PR_DESTINATION_BRANCH')}"
+
+        self.log_info(f"Comparing HEAD against branch {target_branch}")
+
+        # Output is terminated with newline char, remove it.
+        merge_base = subprocess.check_output(["git",
+                                              "merge-base",
+                                              "HEAD",
+                                              target_branch
+                                              ]).decode(sys.stdout.encoding)[:-1]
+
+        changed_files = subprocess.check_output(["git",
+                                                "diff",
+                                                 "--relative",
+                                                 "--name-only",
+                                                 "--diff-filter=AM",
+                                                 merge_base,
+                                                 "--",
+                                                 "*.php"
+                                                 ]).decode(sys.stdout.encoding).split('\n')
+
+        # Filter empty strings
+        changed_files = list(filter(None, changed_files))
+
+        self.log_info(f"Comparing HEAD against merge base {merge_base}")
+        if self.exclude_expression:
+            def filter_paths(path):
+                match = re.search(self.exclude_expression, path)
+                if match:
+                    self.log_info(f"Excluding: {path}")
+                else:
+                    self.log_info(f"Testing: {path}")
+                return not match
+
+            changed_files = list(filter(filter_paths, changed_files))
+
+        else:
+            self.log_info(f"Exclude expression not provided. All changed files will be scanned.")
+
+        if not changed_files:
+            self.success("No changed files to scan")
+            self.failure = False
+            return
+
+        if not os.path.exists("test-results"):
+            os.mkdir("test-results")
+
+        phpstan_command = ["/composer/vendor/bin/phpstan",
+                        changed_files,
+                         "-error-format=junit",
+                         ]
+
+        if self.config_file:
+          phpstan_command.append(f"--configuration={self.config_file}")
+
+        if self.autoloader:
+          phpstan_command.append(f"--autoload-file={self.autoloader}")
+
+        if self.level:
+          phpstan_command.append(f"--level={self.level}")
+
+        phpstan = subprocess.run(phpstan_command, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, universal_newlines=True)
+        self.failure = False if phpstan.returncode == 0 else True
+
+        phpstan_output = phpstan.stdout
+
+        if phpstan_output:
+            with open("test-results/phpstan.xml", 'a') as output_file:
+                output_file.write(phpstan_output)
+
+    def composer_install(self):
+        composer_install_command = ["composer", "install", "--dev"]
+
+        if self.ignore_platform_dependencies:
+          composer_install_command.append('--ignore-platform-dependencies')
+
+        composer_install = subprocess.run(composer_install_command)
+        composer_install.check_returncode()
+
+    def upload_report(self):
+        # Parses a Junit file and returns all errors
+        def read_failures_from_file(file):
+            from junitparser import JUnitXml
+
+            results = []
+            xml = JUnitXml.fromfile(file)
+            if not xml.failures:
+                return []
+            for suite in xml:
+                # handle suites
+                if suite.failures == 0:
+                    continue
+                for case in suite:
+                    for result in case.result:
+                        # Covert paths to relative equivalent
+                        workspace_path = "/opt/atlassian/pipelines/agent/build/"
+                        path = suite.name.replace(workspace_path, '')
+                        results.append({
+                            "path": path,
+                            "title": case.name,
+                            "summary": result.message,
+                            # Extract line number from name
+                            # Example: /some/path/to/file (10:11)
+                            "line": re.search("\((\d*):.*\)", case.name).group(1)
+                        })
+
+            return results
+
+        # Builds a report given a number of failures
+        def build_report_data(failure_count):
+            report_data = [
+                {
+                    "title": 'Failures',
+                    "type": 'NUMBER',
+                    "value": failure_count
+                }
+            ]
+
+            return report_data
+
+        report_id = str(uuid.uuid4())
+
+        bitbucket_api = Bitbucket(
+            proxies={"http": 'http://host.docker.internal:29418'})
+
+        failures = []
+        if os.path.exists("test-results/phpstan.xml"):
+            failures = read_failures_from_file(f"test-results/phpstan.xml")
+
+        bitbucket_api.create_report(
+            "Code standards report",
+            "Results producced by runing phpstan against updated files",
+            "SECURITY",
+            report_id,
+            "phpstan-pipe",
+            "FAILED" if len(failures) else "PASSED",
+            f"https://bitbucket.org/{self.bitbucket_workspace}/{self.bitbucket_repo_slug}/addon/pipelines/home#!/results/{self.bitbucket_pipeline_uuid}/steps/{self.bitbucket_step_uuid}/test-report",
+            build_report_data(len(failures)),
+            self.bitbucket_workspace,
+            self.bitbucket_repo_slug,
+            self.bitbucket_commit
+        )
+
+        for failure in failures:
+            self.log_debug(f"Submitting failure: {failure}")
+            bitbucket_api.create_annotation(
+                failure["title"],
+                failure["summary"],
+                "MEDIUM",
+                failure["path"],
+                failure["line"],
+                "phpstan-pipe",
+                report_id,
+                "CODE_SMELL",
+                str(uuid.uuid4()),
+                self.bitbucket_workspace,
+                self.bitbucket_repo_slug,
+                self.bitbucket_commit
+            )
+
+    def run(self):
+        super().run()
+        if not self.skip_dependencies:
+            self.setup_ssh_credentials()
+            self.composer_install()
+        self.run_phpstan()
+        self.upload_report()
+
+        if self.failure:
+            self.fail(message=f"Failed PHPStan")
+        else:
+            self.success(message=f"PHPStan Passed")
+
+if __name__ == '__main__':
+    pipe = PHPStan(schema=schema, logger=logger)
+    pipe.run()

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -101,6 +101,12 @@ run_phpstan() {
      fi
 }
 
+git_allow_access() {
+     debug "Granting git safe access to bitbucket build directory..."
+     git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
+}
+
+git_allow_access
 validate
 if [ $SKIP_DEPENDENCIES = false ]; then
      setup_ssh_creds

--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -102,8 +102,9 @@ run_phpstan() {
 }
 
 git_allow_access() {
-     debug "Granting git safe access to bitbucket build directory..."
+     debug "Granting git safe access to the directories owned by someone else ..."
      git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
+     git config --global --add safe.directory /app
 }
 
 git_allow_access

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+junitparser
+git+https://github.com/aligent/bitbucket-manager
+bitbucket-pipes-toolkit==3.2.1


### PR DESCRIPTION
This PR migrates this pipe to use python instead of a bash script (I've kept the bash script around for now) it is based on https://github.com/aligent/code-standards-pipe-php

I have removed the MAGENTO_USER and MAGENTO_PASS variables as realistically if you need advanced composer configuration you should do that in a separate step and pass that to this step as an artefact. 